### PR TITLE
⚠️ API Key Exposed in Frontend – Security Vulnerability

### DIFF
--- a/pages/api/weather.js
+++ b/pages/api/weather.js
@@ -1,0 +1,15 @@
+export default async function handler(req, res) {
+  const { location } = req.query;
+  const apiKey = process.env.WEATHER_API_KEY;
+
+  if (!location) return res.status(400).json({ error: 'Location is required' });
+
+  try {
+    const apiUrl = `http://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${location}`;
+    const response = await fetch(apiUrl);
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch weather data' });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,8 +11,7 @@ export default function Home() {
   const [weatherData, setWeatherData] = useState(null);
 
   const getWeather = async () => {
-    const apiKey = '0a5e49c27f2c44c3bb851118251205';
-    const apiUrl = `http://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${location}`;
+    const apiUrl = `/api/weather?location=${location}`;
 
     if (location) {
       try {


### PR DESCRIPTION
### 🐞 Issue: Publicly Exposed API Key in Frontend

In [`pages/index.js`](https://github.com/24roshan/WeatherApp/blob/main/pages/index.js#L14), the API key for the Weather API is **hardcoded directly** in the frontend JavaScript:

```js
const apiKey = '0a5e49c27f2c44c3bb851118251205';
````

This is a serious **security vulnerability** because:

* Anyone can inspect the site and extract this key.
* Malicious users can misuse it, causing rate-limits, bans, or unwanted charges.
* It violates best practices of API key management.

---

### ✅ Recommended Fix:

1. **Move the API logic to a backend route or serverless function**:

   * Use [[Next.js API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes)](https://nextjs.org/docs/pages/building-your-application/routing/api-routes).
   * The API route should make the call to `weatherapi.com` using the secret key.
   * The frontend will then call your internal `/api/weather?location=xyz` route securely.

2. **Remove the hardcoded key from the repo** and store it in `.env.local`:

```env
WEATHER_API_KEY=your_real_key
```

In your API route (`/pages/api/weather.js`):

```js
export default async function handler(req, res) {
  const { location } = req.query;
  const apiKey = process.env.WEATHER_API_KEY;
  const apiUrl = `http://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${location}`;

  try {
    const response = await fetch(apiUrl);
    const data = await response.json();
    res.status(200).json(data);
  } catch (err) {
    res.status(500).json({ error: 'Failed to fetch weather data' });
  }
}
```

Then update your frontend to call `/api/weather`.

---

### 🔒 Why This Matters:

Keeping API keys in the frontend is a **huge attack surface** — especially if the key isn't protected with domain-level restrictions.

---